### PR TITLE
adding locked document in personnal stat

### DIFF
--- a/src/backend/modules/statistic/service/fetchFilteredStatistics.ts
+++ b/src/backend/modules/statistic/service/fetchFilteredStatistics.ts
@@ -24,7 +24,9 @@ async function fetchFilteredStatistics(filter: ressourceFilterType, settings: se
 
   async function computeStatisticsFromDoneDocuments() {
     const doneDocuments = await documentService.fetchDoneDocuments();
-    const documentIds = doneDocuments.map(({ _id }) => _id);
+    const lockedDocuments = await documentService.fetchLockedDocuments();
+    const allDocuments = [...doneDocuments, ...lockedDocuments];
+    const documentIds = allDocuments.map(({ _id }) => _id);
 
     const assignationsByDocumentId: Record<string, assignationType[] | undefined> =
       await assignationService.fetchAssignationsByDocumentIds(documentIds, {
@@ -32,7 +34,7 @@ async function fetchFilteredStatistics(filter: ressourceFilterType, settings: se
       });
     const treatmentsByDocumentId = await treatmentService.fetchTreatmentsByDocumentIds(documentIds);
 
-    const treatedDocuments = doneDocuments.map((document) => {
+    const treatedDocuments = allDocuments.map((document) => {
       const assignations = assignationsByDocumentId[idModule.lib.convertToString(document._id)];
       const treatments = treatmentsByDocumentId[idModule.lib.convertToString(document._id)];
       const humanTreatments = assignations ? treatmentModule.lib.extractHumanTreatments(treatments, assignations) : [];


### PR DESCRIPTION
## Issue description :
Ajouter dans la comptabilisation des stats personnelles des agents les documents bloquèes
## Describe your changes :
fetch locked document and make aggregation for stats
## How to test :
run in local and test with annotator and admin
## Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] The feature works locally.
- [ ] If it's relevant I added tests.
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.
